### PR TITLE
Add workflow runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ require('telescope').load_extension('gh')
 Telescope gh issues
 Telescope gh pull_request
 Telescope gh gist
+Telescope gh run
 
 "Using lua function
 lua require('telescope').extensions.gh.issues()<cr>
 lua require('telescope').extensions.gh.pull_request()<cr>
 lua require('telescope').extensions.gh.gist()<cr>
+lua require('telescope').extensions.gh.run()<cr>
 
 ```
 
@@ -99,5 +101,19 @@ Telescope gh issues author=windwp label=bug
 | `<cr>`  | append gist to buffer |
 | `<c-t>` | open web              |
 
+### Workflow runs
+#### Options Filter
+[Detail](https://cli.github.com/manual/gh_run_list)
 
+| Query     | filter                             |
+|-----------|------------------------------------|
+| workflow  | Filter runs by workflow            |
+| limit     | limit default = 100                |
 
+#### Key mappings
+
+| key     | Usage                         |
+|---------|-------------------------------|
+| `<cr>`  | open run logs in a split      |
+| `<c-t>` | open web                      |
+| `<c-r>` | request run rerun             |

--- a/lua/telescope/_extensions/gh.lua
+++ b/lua/telescope/_extensions/gh.lua
@@ -7,5 +7,6 @@ return require('telescope').register_extension {
       gist = gh_b.gh_gist ,
       issues = gh_b.gh_issues,
       pull_request = gh_b.gh_pull_request ,
+      run = gh_b.gh_run ,
     },
 }

--- a/lua/telescope/_extensions/gh_make_entry.lua
+++ b/lua/telescope/_extensions/gh_make_entry.lua
@@ -1,0 +1,73 @@
+local entry_display = require('telescope.pickers.entry_display')
+local gh_make_entry = {}
+-- local utils = require('telescope.utils')
+
+function gh_make_entry.gen_from_run(opts)
+  opts = opts or {}
+  local icons = {
+    failed    = "X",
+    success   = "✓",
+    working   = "-",
+    cancelled = "C",
+  }
+
+  local displayer = entry_display.create {
+  separator = "|",
+  items = {
+      { width = 2 },
+      { width = 40 },
+      { width = 12 },
+      { remaining = true },
+    }
+  }
+
+  local status_map = {
+    ["success"]          = {icon = icons.success,   hl = "TelescopeResultsDiffAdd"},
+    ["failure"]          = {icon = icons.failed,    hl = "TelescopeResultsDiffDelete"},
+    ["startup_failure"]  = {icon = icons.failed,    hl = "TelescopeResultsDiffDelete"},
+    ["active"]           = {icon = icons.working,   hl = "TelescopeResultsDiffChange"},
+    ["cancelled"]        = {icon = icons.cancelled, hl = "TelescopeResultsDiffDelete"},
+  }
+
+  local make_display = function(entry)
+    local status_x = {}
+    if entry.active ~= "completed" then
+      status_x = status_map["active"]
+    else
+      status_x = status_map[entry.status] or {}
+    end
+
+    local empty_space = ("")
+    return displayer {
+      { status_x.icon or empty_space, status_x.hl },
+      entry.value,
+      entry.workflow,
+      entry.branch,
+      entry.id,
+    }
+  end
+
+  return function (entry)
+    if entry == '' then return nil end
+    local tmp_table = vim.split(entry,"\t");
+    local active = tmp_table[1] or ""
+    local status = tmp_table[2] or ""
+    local description = tmp_table[3] or ""
+    local workflow = tmp_table[4] or ""
+    local branch = tmp_table[5] or ""
+    local id = tmp_table[#tmp_table] or ""
+
+    return {
+      value = description,
+      active = active,
+      status = status,
+      workflow = workflow,
+      branch = branch,
+      id = id,
+      ordinal = entry,
+      display = make_display,
+    }
+  end
+end
+
+return gh_make_entry

--- a/lua/telescope/_extensions/gh_previewers.lua
+++ b/lua/telescope/_extensions/gh_previewers.lua
@@ -59,4 +59,31 @@ P.gh_pr_preview = defaulter(function(opts)
     end
   }
 end, {})
+
+P.gh_run_preview = defaulter(function(opts)
+
+  return previewers.new_buffer_previewer {
+    get_buffer_by_name = function(_, entry)
+      return entry.id
+    end,
+
+    define_preview = function(self, entry)
+      local gh_command = {}
+
+      if entry.id then
+        gh_command ={ 'gh' , 'run' , 'view' , entry.id }
+      else
+        gh_command {"echo" , "empty"}
+      end
+
+      putils.job_maker(gh_command, self.state.bufnr, {
+        value = entry.value,
+        bufname = self.state.bufname,
+        cwd = opts.cwd
+      })
+      putils.regex_highlighter(self.state.bufnr, "text")
+    end
+  }
+end, {})
+
 return P


### PR DESCRIPTION
GitHub CLI tool now provides [functionality](https://cli.github.com/manual/gh_run_list) to list, view, watch logs and restart workflow runs.
This PR adds wrappers to those commands.

Running `Telescope gh run` will open list of runs, showing status, description, workflow and branch.

For preview I use `gh run view`.
Also few key mappings attached:

| key     | Usage                         |
|---------|-------------------------------|
| `<cr>`  | open run logs in a split      |
| `<c-t>` | open web                      |
| `<c-r>` | request run rerun             |