### PR TITLE
Watch unfinished runs and clean log

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,18 @@ Telescope gh issues author=windwp label=bug
 #### Options Filter
 [Detail](https://cli.github.com/manual/gh_run_list)
 
-| Query     | filter                             |
-|-----------|------------------------------------|
-| workflow  | Filter runs by workflow            |
-| limit     | limit default = 100                |
+| Query     | filter                                                |
+|-----------|-------------------------------------------------------|
+| workflow  | Filter runs by workflow                               |
+| limit     | limit default = 100                                   |
+| wincmd    | Command to open log window, default = 'botright vnew' |
+| wrap      | Wrap lines in log window, default = 'nowrap'          |
+| cleanmeta | Try to clean run log lines, default = 'true'          |
 
 #### Key mappings
 
-| key     | Usage                         |
-|---------|-------------------------------|
-| `<cr>`  | open run logs in a split      |
-| `<c-t>` | open web                      |
-| `<c-r>` | request run rerun             |
+| key     | Usage                                        |
+|---------|----------------------------------------------|
+| `<cr>`  | open workflow summary/run logs in new window |
+| `<c-t>` | open web                                     |
+| `<c-r>` | request run rerun                            |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Telescope gh issues author=windwp label=bug
 | limit     | limit default = 100                                   |
 | wincmd    | Command to open log window, default = 'botright vnew' |
 | wrap      | Wrap lines in log window, default = 'nowrap'          |
+| filetype  | Filetype to use on log window, default='bash'         |
 | cleanmeta | Try to clean run log lines, default = 'true'          |
 
 #### Key mappings

--- a/lua/telescope/_extensions/gh_actions.lua
+++ b/lua/telescope/_extensions/gh_actions.lua
@@ -135,6 +135,7 @@ end
 
 A.gh_run_rerun=function(prompt_bufnr)
   local selection = action_state.get_selected_entry(prompt_bufnr)
+  print(selection.id)
   actions.close(prompt_bufnr)
   if selection.id == "" then
     return
@@ -143,54 +144,75 @@ A.gh_run_rerun=function(prompt_bufnr)
   os.execute('gh run rerun ' .. selection.id)
 end
 
-A.gh_run_view_log=function(prompt_bufnr)
-  local selection = action_state.get_selected_entry(prompt_bufnr)
-  actions.close(prompt_bufnr)
-  if selection.id == "" then
-    return
-  end
-  local log_output = {}
-  vim.api.nvim_command('botright vnew')
-  local buf = vim.api.nvim_get_current_buf()
+A.gh_run_view_log=function(opts)
+  return function(prompt_bufnr)
+    local selection = action_state.get_selected_entry(prompt_bufnr)
+    actions.close(prompt_bufnr)
+    if selection.id == "" then
+      return
+    end
+    local log_output = {}
+    vim.api.nvim_command(opts.wincmd)
+    local buf = vim.api.nvim_get_current_buf()
 
-  vim.api.nvim_buf_set_name(0, 'result #' .. buf)
+    vim.api.nvim_buf_set_name(0, 'result #' .. buf)
 
-  vim.api.nvim_buf_set_option(0, 'buftype', 'nofile')
-  vim.api.nvim_buf_set_option(0, 'swapfile', false)
-  vim.api.nvim_buf_set_option(0, 'filetype', 'result')
-  vim.api.nvim_buf_set_option(0, 'bufhidden', 'wipe')
+    vim.api.nvim_buf_set_option(0, 'buftype', 'nofile')
+    vim.api.nvim_buf_set_option(0, 'swapfile', false)
+    vim.api.nvim_buf_set_option(0, 'filetype', 'result')
+    vim.api.nvim_buf_set_option(0, 'bufhidden', 'wipe')
+    vim.api.nvim_command('setlocal ' .. opts.wrap)
+    vim.api.nvim_command('setlocal cursorline')
 
-  vim.api.nvim_command('setlocal wrap')
-  vim.api.nvim_command('setlocal cursorline')
+    local args = {}
+    local run_completed = false
+    if selection.status == "success" or selection.status == "failure" then
+      run_completed = true
+    end
+    if run_completed then
+      args = {"run", "view" , "--log", selection.id}
+    else
+      args = {"run", "watch", selection.id}
+    end
 
-  local on_output = function(_, line)
-    table.insert(log_output,line)
-    pcall(vim.schedule_wrap( function()
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, log_output)
-     end))
-  end
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {"Retrieving log, please wait..."})
 
-  local job = Job:new({
-      enable_recording = true ,
-      command = "gh",
-      args = flatten{"run", "view" , "--log", selection.id},
-      on_stdout = on_output,
-      on_stderr = on_output,
+    local on_output = function(_, line)
+      if not run_completed and string.find(line, "Refreshing") then
+        log_output = {}
+      end
+      if opts.cleanmeta and run_completed then
+        -- Lua doesn't support capture group quantifier
+        local tmp = string.gsub(line, "(.*\t)", "")
+        line = string.gsub(tmp, "(.*%d+Z)", "")
+      end
+      table.insert(log_output, line)
 
-      on_exit = function(_,status)
-        if status == 0 then
-           print("Log retrieval completed!")
+      pcall(vim.schedule_wrap( function()
+        if vim.api.nvim_buf_is_valid(buf) then
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, log_output)
         end
-      end,
-    })
+      end))
+    end
 
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {"Retrieving log, please wait..."})
-  local timer = vim.loop.new_timer()
-  timer:start(200, 0, vim.schedule_wrap(function()
-    -- increase timeout to 10000ms and wait interval to 20
-    -- default value is 5000ms and 10
-    job:sync(10000,20)
-  end))
+    local job = Job:new({
+        enable_recording = true ,
+        command = "gh",
+        args = flatten(args),
+        on_stdout = on_output,
+        on_stderr = on_output,
+
+        on_exit = function(_,status)
+          if status == 0 then
+            if run_completed then
+              print("Log retrieval completed!")
+            else
+              print("Workflow run completed!")
+            end
+          end
+        end,
+      }):sync()
+  end
 end
 
 return A

--- a/lua/telescope/_extensions/gh_actions.lua
+++ b/lua/telescope/_extensions/gh_actions.lua
@@ -159,7 +159,7 @@ A.gh_run_view_log=function(opts)
 
     vim.api.nvim_buf_set_option(0, 'buftype', 'nofile')
     vim.api.nvim_buf_set_option(0, 'swapfile', false)
-    vim.api.nvim_buf_set_option(0, 'filetype', 'result')
+    vim.api.nvim_buf_set_option(0, 'filetype', opts.filetype)
     vim.api.nvim_buf_set_option(0, 'bufhidden', 'wipe')
     vim.api.nvim_command('setlocal ' .. opts.wrap)
     vim.api.nvim_command('setlocal cursorline')
@@ -181,10 +181,17 @@ A.gh_run_view_log=function(opts)
       if not run_completed and string.find(line, "Refreshing") then
         log_output = {}
       end
-      if opts.cleanmeta and run_completed then
-        -- Lua doesn't support capture group quantifier
-        local tmp = string.gsub(line, "(.*\t)", "")
-        line = string.gsub(tmp, "(.*%d+Z)", "")
+      local cleanmsg = function(msgtoclean)
+        local msgwithoutdate = string.match(msgtoclean, 'T%d%d:%d%d:%d%d.%d+Z(.+)$')
+        if msgwithoutdate ~= nil then
+          return msgwithoutdate
+        else
+          return msgtoclean
+        end
+      end
+      local tbl_msg = vim.split(line, '\t', true)
+      if opts.cleanmeta and run_completed and #tbl_msg == 3 then
+        line = cleanmsg(tbl_msg[3])
       end
       table.insert(log_output, line)
 

--- a/lua/telescope/_extensions/gh_builtin.lua
+++ b/lua/telescope/_extensions/gh_builtin.lua
@@ -165,6 +165,9 @@ end
 B.gh_run = function(opts)
   opts = opts or {}
   opts.limit = opts.limit or 100
+  opts.wincmd = opts.wincmd or 'botright vnew'
+  opts.wrap = opts.wrap or 'nowrap'
+  if opts.cleanmeta == nil then opts.cleanmeta = true end
   local opts_query = parse_opts(opts , 'run')
   local cmd = vim.tbl_flatten({'gh' , 'run' , 'list' , opts_query})
   local title = 'Workflow runs'
@@ -184,7 +187,7 @@ B.gh_run = function(opts)
         attach_mappings = function(_,map)
           map('i','<c-r>',gh_a.gh_run_rerun)
           map('i','<c-t>',gh_a.gh_run_web_view)
-          actions.select_default:replace(gh_a.gh_run_view_log)
+          actions.select_default:replace(gh_a.gh_run_view_log(opts))
           return true
         end
       }):find()

--- a/lua/telescope/_extensions/gh_builtin.lua
+++ b/lua/telescope/_extensions/gh_builtin.lua
@@ -167,6 +167,7 @@ B.gh_run = function(opts)
   opts.limit = opts.limit or 100
   opts.wincmd = opts.wincmd or 'botright vnew'
   opts.wrap = opts.wrap or 'nowrap'
+  opts.filetype = opts.filetype or 'bash'
   if opts.cleanmeta == nil then opts.cleanmeta = true end
   local opts_query = parse_opts(opts , 'run')
   local cmd = vim.tbl_flatten({'gh' , 'run' , 'list' , opts_query})


### PR DESCRIPTION
This PR amends workflow functionality so that:
- if github workflow is still running, `gh run watch <id>` will be executed, dynamically populating window with output
- if github worklow is completed, `gh run view --log <id>` will be run.

Also this PR adds few options:

| Query     | filter                                                |
|-----------|-------------------------------------------------------|
| wincmd    | Command to open log window, default = 'botright vnew' |
| wrap      | Wrap lines in log window, default = 'nowrap'          |
| cleanmeta | Try to clean run log lines, default = 'true'          |

With `cleanmeta`, logs will be cleaned from:
```bash
get-repos	Set up job	2021-06-03T06:36:11.7784122Z Image Release: https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20210524.1
```
to:
```bash
 Image Release: https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20210524.1
```
