### PR TITLE
Use `get_current_picker` from `actions.state`

### DIFF
--- a/lua/telescope/_extensions/gh_actions.lua
+++ b/lua/telescope/_extensions/gh_actions.lua
@@ -101,7 +101,7 @@ A.gh_pr_v_toggle = function(prompt_bufnr)
     status.gh_pr_preview = 'diff'
   end
   local entry = action_state.get_selected_entry(prompt_bufnr)
-  actions.get_current_picker(prompt_bufnr).previewer:preview(
+  action_state.get_current_picker(prompt_bufnr).previewer:preview(
       entry,
       status
   )


### PR DESCRIPTION
`get_current_picker` was moved from `actions` to `actions.state` https://github.com/nvim-telescope/telescope.nvim/pull/472