### PR TITLE
Feature: insert issue reference on <CR>

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Telescope gh issues author=windwp label=bug
 
 | key     | Usage    |
 |---------|----------|
-| `<cr>`  | nothing  |
+| `<cr>`  | insert a reference to the issue |
 | `<c-t>` | open web |
 
 ### Gist

--- a/lua/telescope/_extensions/gh_actions.lua
+++ b/lua/telescope/_extensions/gh_actions.lua
@@ -64,6 +64,14 @@ local function gh_qf_action(pr_number, action, msg)
 	)
 end
 -- a for actions
+A.gh_issue_insert = function(prompt_bufnr)
+	-- Insert “#10” if issue 10 was selected
+	local issue_number = close_telescope_prompt(prompt_bufnr)
+	if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
+		vim.api.nvim_put({ "#"..issue_number }, "b", true, true)
+	end
+end
+
 A.gh_pr_checkout = function(prompt_bufnr)
 	local pr_number = close_telescope_prompt(prompt_bufnr)
 	gh_qf_action(pr_number, "checkout", "Checking out pull request #")

--- a/lua/telescope/_extensions/gh_builtin.lua
+++ b/lua/telescope/_extensions/gh_builtin.lua
@@ -108,7 +108,7 @@ B.gh_issues = function(opts)
 			}),
 			sorter = conf.file_sorter(opts),
 			attach_mappings = function(_, map)
-				actions.select_default:replace(actions.close)
+				actions.select_default:replace(gh_a.gh_issue_insert)
 				map("i", "<c-t>", gh_a.gh_web_view("issue"))
 				return true
 			end,


### PR DESCRIPTION
Currently, `<CR>` is set to “close Telescope”. There is already a
generic “cancel” mapping for that. I find more useful to just insert the
selected issue in the buffer we come from.

This allows to insert references to GitHub issues in commit messages,
code comments…
