### PR TITLE
fix(gist): set higher default limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Telescope gh issues author=windwp label=bug
 |-----------|------------------------------------|
 | public    | Filter by public                   |
 | secret    | Filter by secret                   |
+| limit     | limit default = 100                |
 
 ### Key mappings
 | key     | Usage                    |

--- a/lua/telescope/_extensions/gh_builtin.lua
+++ b/lua/telescope/_extensions/gh_builtin.lua
@@ -25,7 +25,7 @@ local function parse_opts(opts, target)
   elseif target == "run" then
     tmp_table = { "workflow", "limit" }
   elseif target == "gist" then
-    tmp_table = { "public", "secret" }
+    tmp_table = { "public", "secret", "limit" }
     if opts.public then
       opts.public = " "
     end


### PR DESCRIPTION
By default, `gh gist list` only returns 10 gists, which is pretty small to be useful. This PR allows you to set the limit AND increases the default to 100 instead of 10 (default of `gh` itself)